### PR TITLE
Fix citation-string crash on non-latin1 characters, and stop the year filter silently dropping citations

### DIFF
--- a/citations_fun/filterCitations.py
+++ b/citations_fun/filterCitations.py
@@ -2,40 +2,53 @@ import pandas as pd
 
 
 def filterCitations(nerc_citations_df):
+    """
+    Remove citations we don't want to surface, returning (kept_df, filtered_out_df).
 
-    # comments on pre-prints, begin with: "Comment on" "Reply on" "Reply to comment by" "final response"
-    pub_title_filter_list = ("Comment on", "Reply on", "Reply to comment by", "final response")
-    filtered_out_df = nerc_citations_df[nerc_citations_df['pub_title'].str.startswith(pub_title_filter_list)]
-    nerc_citations_df_filtered = nerc_citations_df[~nerc_citations_df['pub_title'].str.startswith(pub_title_filter_list)]
+    Fixes vs the previous version:
+      * The kept frame is now carried forward through every step. Previously the
+        peer-review step recomputed `nerc_citations_df_filtered` from the ORIGINAL
+        input, silently undoing the comment/reply title filter.
+      * Years are coerced with pd.to_numeric(errors="coerce"); rows whose
+        publication year can't be parsed (None / "Info not given" / "API request
+        failed") now end up NaN and are KEPT, instead of being silently dropped
+        from both the kept and filtered-out frames (a likely contributor to
+        "missing citations", issue #11). A non-numeric value also no longer
+        crashes .astype("float").
+      * .str accessors use na=False so NaN titles/types/DOIs don't raise.
+    """
+    df = nerc_citations_df.copy()
+    filtered_out_parts = []
 
-    # publication.types ="peer-review"
-    pub_type_filter_list = ("peer-review")
-    result = nerc_citations_df[nerc_citations_df['pub_type'].str.startswith(pub_type_filter_list)]
-    filtered_out_df = pd.concat([filtered_out_df, result], ignore_index=True)
-    nerc_citations_df_filtered = nerc_citations_df[~nerc_citations_df['pub_type'].str.startswith(pub_type_filter_list)]
+    # 1. Comments / replies on pre-prints (by title prefix).
+    title_filters = ("Comment on", "Reply on", "Reply to comment by", "final response")
+    is_comment = df["pub_title"].str.startswith(title_filters, na=False)
+    filtered_out_parts.append(df[is_comment])
+    df = df[~is_comment]
 
-    # if pub_doi contians:
-    # "egusphere" - always a conference abstract
-    # "10.15468" - gbif dataset downloads
-    # define list of strings to look for and join with or | statements
-    pub_doi_filter_list = ("egusphere", "10.15468")
-    pattern = "|".join(pub_doi_filter_list)
-    result = nerc_citations_df_filtered[nerc_citations_df_filtered['pub_doi'].str.contains(pattern, na=False)]
-    filtered_out_df = pd.concat([filtered_out_df, result], ignore_index=True)
-    nerc_citations_df_filtered = nerc_citations_df_filtered[~nerc_citations_df_filtered['pub_doi'].str.contains(pattern, na=False)]
+    # 2. Peer-review publication type.
+    is_peer_review = df["pub_type"].str.startswith("peer-review", na=False)
+    filtered_out_parts.append(df[is_peer_review])
+    df = df[~is_peer_review]
 
-    # remove results where the data is published after the publication - the data must be citing the publication
+    # 3. Unwanted publication DOIs:
+    #    "egusphere" -> always a conference abstract; "10.15468" -> GBIF dataset downloads.
+    #    (10\.15468 is escaped so the dot matches a literal dot, not any character.)
+    pub_doi_pattern = "|".join(("egusphere", r"10\.15468"))
+    is_excluded_doi = df["pub_doi"].str.contains(pub_doi_pattern, na=False, regex=True)
+    filtered_out_parts.append(df[is_excluded_doi])
+    df = df[~is_excluded_doi]
 
-    # find the rows where api request failed and the year is a string
-    temp_API_failed = nerc_citations_df_filtered[nerc_citations_df_filtered['publicationYear'] == "API request failed"]
-    # find the rest of the rows where publicationYear is a number
-    temp_pub_year_ok = nerc_citations_df_filtered[nerc_citations_df_filtered['publicationYear'] != "API request failed"]
-    # find rows where publicationYear is BEFORE data were published and add to filtered_out_df
-    result = temp_pub_year_ok[temp_pub_year_ok['publicationYear'].astype('float') < temp_pub_year_ok['data_publication_year'].astype('float')]
-    filtered_out_df = pd.concat([filtered_out_df, result], ignore_index=True)
-    # find rows where publicationYear is AFTER data were published and add to filtered_out_df using the number only df
-    nerc_citations_df_filtered = temp_pub_year_ok[temp_pub_year_ok['publicationYear'].astype('float') >= temp_pub_year_ok['data_publication_year'].astype('float')]
-    # add back in the rows where publicationYear is 'api request failed'
-    nerc_citations_df_filtered = pd.concat([nerc_citations_df_filtered, temp_API_failed], ignore_index=True)
+    # 4. The publication must not pre-date the data it cites.
+    #    Coerce both years to numeric; unparseable -> NaN. NaN comparisons are
+    #    False, so rows with an unknown year are kept (not dropped).
+    pub_year = pd.to_numeric(df["publicationYear"], errors="coerce")
+    data_year = pd.to_numeric(df["data_publication_year"], errors="coerce")
+    predates_data = pub_year < data_year
+    filtered_out_parts.append(df[predates_data])
+    df = df[~predates_data]
 
-    return (nerc_citations_df_filtered, filtered_out_df)
+    filtered_out_df = (pd.concat(filtered_out_parts, ignore_index=True)
+                       if filtered_out_parts else df.iloc[0:0].copy())
+
+    return (df, filtered_out_df)

--- a/citations_fun/getCitationString.py
+++ b/citations_fun/getCitationString.py
@@ -24,32 +24,37 @@ def get_citation_str(nerc_citations_df):
 
     for pubDOI in nerc_citations_df['pub_doi']:
         time.sleep(0.1)
-        if pubDOI.startswith('10.'):
-            print(pubDOI)
-            result = None
-            try:
-                # Set a timeout for the request
-                # r = session.get(("https://citation.crosscite.org/format?style=frontiers-of-biogeography&lang=en-GB&doi=" + pubDOI),
-                #                 headers={"Accept": "text/x-bibliography", "Accept-Charset": "utf-8"}, timeout=timeout_seconds)
-                r = session.get(("https://citation.doi.org/format?style=frontiers-of-biogeography&lang=en-GB&doi=" + pubDOI),
-                                headers={"Accept": "text/x-bibliography", "Accept-Charset": "utf-8"}, timeout=timeout_seconds)
-                print(r.status_code)
-                encoded_citation = r.text
-                # Decode the author names assuming UTF-8 encoding
-                result = encoded_citation.encode('latin1').decode('utf-8')
-            except Timeout:
-                print(f"Request for {pubDOI} timed out.")
-            except ConnectionError as ce:
-                print(f"A connection error occurred for {pubDOI}: {ce}")
-            except Exception as e:
-                print(f"An error occurred for {pubDOI}: {e}")
-                if 'r' in locals() and r.text:
-                    result = r.text
-
-            finally:
-                citationStrList.append(result if result is not None else 'error occurred')
-        else:
+        # Guard against non-string / missing DOIs (avoids AttributeError on NaN).
+        if not isinstance(pubDOI, str) or not pubDOI.startswith('10.'):
             citationStrList.append('not a doi')
+            continue
+
+        print(pubDOI)
+        result = None
+        r = None  # reset every iteration so a failed request can't reuse a previous response
+        try:
+            r = session.get(("https://citation.doi.org/format?style=frontiers-of-biogeography&lang=en-GB&doi=" + pubDOI),
+                            headers={"Accept": "text/x-bibliography", "Accept-Charset": "utf-8"}, timeout=timeout_seconds)
+            print(r.status_code)
+            # The formatter returns UTF-8. requests defaults to ISO-8859-1 for text/*
+            # when the charset is absent, so force UTF-8 and read the text directly.
+            # This replaces the old `r.text.encode('latin1').decode('utf-8')` round-trip,
+            # which raised UnicodeEncodeError on any character outside latin1 (e.g. the
+            # en-dash U+2013 used in page ranges like "1861-1875") -- issue #17.
+            r.encoding = "utf-8"
+            result = r.text
+        except Timeout:
+            print(f"Request for {pubDOI} timed out.")
+        except ConnectionError as ce:
+            print(f"A connection error occurred for {pubDOI}: {ce}")
+        except Exception as e:
+            print(f"An error occurred for {pubDOI}: {e}")
+            if r is not None and r.text:
+                r.encoding = "utf-8"
+                result = r.text
+
+        finally:
+            citationStrList.append(result if result is not None else 'error occurred')
 
     nerc_citations_df['pub_citation_str'] = citationStrList # add the citation string list to df
     print('Done!')

--- a/citations_fun/getPublicationInfo_forDataCite.py
+++ b/citations_fun/getPublicationInfo_forDataCite.py
@@ -68,7 +68,7 @@ def getPublicationInfo(datacite_doi_events_df):
                     authors = "Info not given"
 
             try:
-                publisher = data['type'] # was ['publisher']
+                publisher = data['publisher']
             except:
                 publisher = "Info not given"
                 

--- a/citations_fun/getPublicationType_forScholex.py
+++ b/citations_fun/getPublicationType_forScholex.py
@@ -1,3 +1,4 @@
+import requests
 
 # Check publication type 
 def checkDOIpubType(publicationDOI):


### PR DESCRIPTION
# Fix citation pipeline: encoding crash, dropped citations, publisher field, and missing import

## Summary

Two independent bugs in the citation pipeline. The first corrupts citation
*display* text; the second silently *drops* citations from the results. Both
affect all data centres (including NGDC/BGS).

- **`getCitationString.py`** — replace the `r.text.encode('latin1').decode('utf-8')`
  round-trip with reading the response as UTF-8 directly.
- **`filterCitations.py`** — coerce years with `pd.to_numeric(errors="coerce")`
  so publications with an unparseable/missing year are no longer dropped, and
  carry one frame through every filter step.
- **`getPublicationInfo_forDataCite.py`** — set the publisher column from the
  publisher, not the resource type.
- **`getPublicationType_forScholex.py`** — add the missing module-level
  `import requests`.

Closes #17. Contributes to #11 (see *Note on #11* below — this is not the full
story).

## Background / root causes

**#17 — "citation characters falling over".** `get_citation_str` post-processed
the formatter response with:

```python
result = encoded_citation.encode('latin1').decode('utf-8')
```

That repairs mojibake when `requests` decoded UTF-8 bytes as ISO-8859-1 (no
charset on the response), but it raises `UnicodeEncodeError` on any character
outside latin1. Citation page ranges contain an en-dash `–` (U+2013), so e.g.
`10.5194/cp-20-1861-2024` ("… 1861–1875") fails:

```
'latin-1' codec can't encode character '\u2013' in position 44: ordinal not in range(256)
```

…and the row ends up as `"error occurred"`. Forcing UTF-8 on the response is
correct whether or not the server sends a charset, fixes the en-dash case, and
still renders accented author names correctly (no more `MÃ¼ller`).

**Year filter silently dropping citations.** In `filterCitations`:

```python
... temp_pub_year_ok['publicationYear'].astype('float') < ...['data_publication_year'].astype('float')
... temp_pub_year_ok['publicationYear'].astype('float') >= ...
```

`publicationYear` is `None` whenever `pub_date` didn't parse. `.astype('float')`
turns that into `NaN`, and `NaN` fails **both** `<` and `>=`, so those rows fall
out of *both* the kept and filtered-out frames and disappear with no record. A
non-numeric value would instead crash `.astype('float')` and take the whole step
down. Coercing with `pd.to_numeric(errors="coerce")` and keeping anything not
provably pre-dating fixes both.

## Changes

**`citations_fun/getCitationString.py`**
- Read the formatter response as UTF-8 (`r.encoding = "utf-8"; result = r.text`)
  instead of the latin1 round-trip.
- Reset `r = None` each iteration and check `r is not None`, so a request that
  fails before assignment can't reuse the previous response and attach the wrong
  publication's citation string to a DOI.
- Guard non-string/missing DOIs before `.startswith`.

**`citations_fun/filterCitations.py`**
- Coerce `publicationYear` and `data_publication_year` with
  `pd.to_numeric(errors="coerce")`; only filter rows where `pub_year < data_year`
  is true, so unknown-year rows (incl. `"API request failed"`) are kept.
- Carry a single frame through every step. Previously the peer-review step
  recomputed the kept frame from the original input, undoing the comment/reply
  title filter.
- Pass `na=False` to the `.str` filters so NaN titles/types/DOIs don't raise.
- Escape the GBIF prefix in the contains pattern (`10\.15468`).

**`citations_fun/getPublicationInfo_forDataCite.py`**
- `publisher = data['type']` → `publisher = data['publisher']`. The column was
  being filled with the resource type instead of the publisher.

**`citations_fun/getPublicationType_forScholex.py`**
- Add a module-level `import requests`. `checkDOIpubType` uses `requests` but it
  was only imported inside `getPublicationType`, so `checkDOIpubType` raised
  `NameError` (swallowed by its bare `except`) and returned `'unknown'` for every
  record — disabling the fast first-pass publication-type lookup.

## Testing

- Reproduced the #17 `UnicodeEncodeError` on a U+2013 page range and confirmed
  the UTF-8 path returns the string intact (and still fixes `MÃ¼ller`).
- Unit-tested `filterCitations` on rows covering: comment/reply title,
  peer-review type, GBIF DOI, pre-dating publication, valid citation, `None`
  year, and `"API request failed"`. Result: input count == kept + filtered-out
  (no silent drops); the period/uppercase DOI `10.1080/1755876X.2016.1273446`
  and the unknown-year rows are retained; intended exclusions still removed.

## Behaviour change for reviewers

The year-filter fix means citations whose publication year couldn't be parsed
are **no longer dropped**, so `Results/v3/latest_results.csv` should gain rows
versus the previous run. That increase is expected. Worth diffing the results
before/after and spot-checking the recovered rows.

## Note on #11

The issue hypothesises that publication DOIs with full-stops/uppercase are being
dropped. I couldn't find any code path that mangles or excludes DOIs on that
basis — the example DOI passes the whole pipeline in testing — so this MR does
**not** claim to close #11. What it fixes is a real, separate mechanism (the
year filter) that does silently drop citations. The remaining suspects are
upstream coverage and the Scholix endpoint; recommend confirming whether the
missing publications appear in the pre-filter intermediates before closing #11.