### PR TITLE
Migrate Scholix citation retrieval to OpenAIRE Scholexplorer v3

### DIFF
--- a/citations_fun/filterCitations.py
+++ b/citations_fun/filterCitations.py
@@ -2,40 +2,53 @@ import pandas as pd
 
 
 def filterCitations(nerc_citations_df):
+    """
+    Remove citations we don't want to surface, returning (kept_df, filtered_out_df).
 
-    # comments on pre-prints, begin with: "Comment on" "Reply on" "Reply to comment by" "final response"
-    pub_title_filter_list = ("Comment on", "Reply on", "Reply to comment by", "final response")
-    filtered_out_df = nerc_citations_df[nerc_citations_df['pub_title'].str.startswith(pub_title_filter_list)]
-    nerc_citations_df_filtered = nerc_citations_df[~nerc_citations_df['pub_title'].str.startswith(pub_title_filter_list)]
+    Fixes vs the previous version:
+      * The kept frame is now carried forward through every step. Previously the
+        peer-review step recomputed `nerc_citations_df_filtered` from the ORIGINAL
+        input, silently undoing the comment/reply title filter.
+      * Years are coerced with pd.to_numeric(errors="coerce"); rows whose
+        publication year can't be parsed (None / "Info not given" / "API request
+        failed") now end up NaN and are KEPT, instead of being silently dropped
+        from both the kept and filtered-out frames (a likely contributor to
+        "missing citations", issue #11). A non-numeric value also no longer
+        crashes .astype("float").
+      * .str accessors use na=False so NaN titles/types/DOIs don't raise.
+    """
+    df = nerc_citations_df.copy()
+    filtered_out_parts = []
 
-    # publication.types ="peer-review"
-    pub_type_filter_list = ("peer-review")
-    result = nerc_citations_df[nerc_citations_df['pub_type'].str.startswith(pub_type_filter_list)]
-    filtered_out_df = pd.concat([filtered_out_df, result], ignore_index=True)
-    nerc_citations_df_filtered = nerc_citations_df[~nerc_citations_df['pub_type'].str.startswith(pub_type_filter_list)]
+    # 1. Comments / replies on pre-prints (by title prefix).
+    title_filters = ("Comment on", "Reply on", "Reply to comment by", "final response")
+    is_comment = df["pub_title"].str.startswith(title_filters, na=False)
+    filtered_out_parts.append(df[is_comment])
+    df = df[~is_comment]
 
-    # if pub_doi contians:
-    # "egusphere" - always a conference abstract
-    # "10.15468" - gbif dataset downloads
-    # define list of strings to look for and join with or | statements
-    pub_doi_filter_list = ("egusphere", "10.15468")
-    pattern = "|".join(pub_doi_filter_list)
-    result = nerc_citations_df_filtered[nerc_citations_df_filtered['pub_doi'].str.contains(pattern, na=False)]
-    filtered_out_df = pd.concat([filtered_out_df, result], ignore_index=True)
-    nerc_citations_df_filtered = nerc_citations_df_filtered[~nerc_citations_df_filtered['pub_doi'].str.contains(pattern, na=False)]
+    # 2. Peer-review publication type.
+    is_peer_review = df["pub_type"].str.startswith("peer-review", na=False)
+    filtered_out_parts.append(df[is_peer_review])
+    df = df[~is_peer_review]
 
-    # remove results where the data is published after the publication - the data must be citing the publication
+    # 3. Unwanted publication DOIs:
+    #    "egusphere" -> always a conference abstract; "10.15468" -> GBIF dataset downloads.
+    #    (10\.15468 is escaped so the dot matches a literal dot, not any character.)
+    pub_doi_pattern = "|".join(("egusphere", r"10\.15468"))
+    is_excluded_doi = df["pub_doi"].str.contains(pub_doi_pattern, na=False, regex=True)
+    filtered_out_parts.append(df[is_excluded_doi])
+    df = df[~is_excluded_doi]
 
-    # find the rows where api request failed and the year is a string
-    temp_API_failed = nerc_citations_df_filtered[nerc_citations_df_filtered['publicationYear'] == "API request failed"]
-    # find the rest of the rows where publicationYear is a number
-    temp_pub_year_ok = nerc_citations_df_filtered[nerc_citations_df_filtered['publicationYear'] != "API request failed"]
-    # find rows where publicationYear is BEFORE data were published and add to filtered_out_df
-    result = temp_pub_year_ok[temp_pub_year_ok['publicationYear'].astype('float') < temp_pub_year_ok['data_publication_year'].astype('float')]
-    filtered_out_df = pd.concat([filtered_out_df, result], ignore_index=True)
-    # find rows where publicationYear is AFTER data were published and add to filtered_out_df using the number only df
-    nerc_citations_df_filtered = temp_pub_year_ok[temp_pub_year_ok['publicationYear'].astype('float') >= temp_pub_year_ok['data_publication_year'].astype('float')]
-    # add back in the rows where publicationYear is 'api request failed'
-    nerc_citations_df_filtered = pd.concat([nerc_citations_df_filtered, temp_API_failed], ignore_index=True)
+    # 4. The publication must not pre-date the data it cites.
+    #    Coerce both years to numeric; unparseable -> NaN. NaN comparisons are
+    #    False, so rows with an unknown year are kept (not dropped).
+    pub_year = pd.to_numeric(df["publicationYear"], errors="coerce")
+    data_year = pd.to_numeric(df["data_publication_year"], errors="coerce")
+    predates_data = pub_year < data_year
+    filtered_out_parts.append(df[predates_data])
+    df = df[~predates_data]
 
-    return (nerc_citations_df_filtered, filtered_out_df)
+    filtered_out_df = (pd.concat(filtered_out_parts, ignore_index=True)
+                       if filtered_out_parts else df.iloc[0:0].copy())
+
+    return (df, filtered_out_df)

--- a/citations_fun/getCitationString.py
+++ b/citations_fun/getCitationString.py
@@ -24,32 +24,37 @@ def get_citation_str(nerc_citations_df):
 
     for pubDOI in nerc_citations_df['pub_doi']:
         time.sleep(0.1)
-        if pubDOI.startswith('10.'):
-            print(pubDOI)
-            result = None
-            try:
-                # Set a timeout for the request
-                # r = session.get(("https://citation.crosscite.org/format?style=frontiers-of-biogeography&lang=en-GB&doi=" + pubDOI),
-                #                 headers={"Accept": "text/x-bibliography", "Accept-Charset": "utf-8"}, timeout=timeout_seconds)
-                r = session.get(("https://citation.doi.org/format?style=frontiers-of-biogeography&lang=en-GB&doi=" + pubDOI),
-                                headers={"Accept": "text/x-bibliography", "Accept-Charset": "utf-8"}, timeout=timeout_seconds)
-                print(r.status_code)
-                encoded_citation = r.text
-                # Decode the author names assuming UTF-8 encoding
-                result = encoded_citation.encode('latin1').decode('utf-8')
-            except Timeout:
-                print(f"Request for {pubDOI} timed out.")
-            except ConnectionError as ce:
-                print(f"A connection error occurred for {pubDOI}: {ce}")
-            except Exception as e:
-                print(f"An error occurred for {pubDOI}: {e}")
-                if 'r' in locals() and r.text:
-                    result = r.text
-
-            finally:
-                citationStrList.append(result if result is not None else 'error occurred')
-        else:
+        # Guard against non-string / missing DOIs (avoids AttributeError on NaN).
+        if not isinstance(pubDOI, str) or not pubDOI.startswith('10.'):
             citationStrList.append('not a doi')
+            continue
+
+        print(pubDOI)
+        result = None
+        r = None  # reset every iteration so a failed request can't reuse a previous response
+        try:
+            r = session.get(("https://citation.doi.org/format?style=frontiers-of-biogeography&lang=en-GB&doi=" + pubDOI),
+                            headers={"Accept": "text/x-bibliography", "Accept-Charset": "utf-8"}, timeout=timeout_seconds)
+            print(r.status_code)
+            # The formatter returns UTF-8. requests defaults to ISO-8859-1 for text/*
+            # when the charset is absent, so force UTF-8 and read the text directly.
+            # This replaces the old `r.text.encode('latin1').decode('utf-8')` round-trip,
+            # which raised UnicodeEncodeError on any character outside latin1 (e.g. the
+            # en-dash U+2013 used in page ranges like "1861-1875") -- issue #17.
+            r.encoding = "utf-8"
+            result = r.text
+        except Timeout:
+            print(f"Request for {pubDOI} timed out.")
+        except ConnectionError as ce:
+            print(f"A connection error occurred for {pubDOI}: {ce}")
+        except Exception as e:
+            print(f"An error occurred for {pubDOI}: {e}")
+            if r is not None and r.text:
+                r.encoding = "utf-8"
+                result = r.text
+
+        finally:
+            citationStrList.append(result if result is not None else 'error occurred')
 
     nerc_citations_df['pub_citation_str'] = citationStrList # add the citation string list to df
     print('Done!')

--- a/citations_fun/getPublicationInfo_forDataCite.py
+++ b/citations_fun/getPublicationInfo_forDataCite.py
@@ -68,7 +68,7 @@ def getPublicationInfo(datacite_doi_events_df):
                     authors = "Info not given"
 
             try:
-                publisher = data['type'] # was ['publisher']
+                publisher = data['publisher']
             except:
                 publisher = "Info not given"
                 

--- a/citations_fun/getPublicationType_forScholex.py
+++ b/citations_fun/getPublicationType_forScholex.py
@@ -1,3 +1,4 @@
+import requests
 
 # Check publication type 
 def checkDOIpubType(publicationDOI):

--- a/citations_fun/getScholixCitations.py
+++ b/citations_fun/getScholixCitations.py
@@ -1,114 +1,135 @@
-# A function to retrieve citation information from Scholix API
+# Retrieve citation information from the OpenAIRE Scholexplorer v3 API.
+#
+# Migrated from v2 to v3 (https://api.scholexplorer.openaire.eu/v3/Links).
+#
+# Direction matters. Scholexplorer stores relationships on the *active side* of
+# the verb ("A Cites B", never "B IsCitedBy A"). To find the works that cite a
+# dataset, the dataset is the TARGET of the relationship and the citing work is
+# the SOURCE -- so we query by `targetPid=<dataset DOI>` and read `source`.
+# The previous v2 code queried `sourcePid` and kept only
+# RelationshipType.Name == "IsReferencedBy"; under v3 the Name is "IsRelatedTo"
+# (the semantic lives in SubType, e.g. "cites"), so that filter matched nothing
+# and the wrong direction was queried -- dropping citations.
+#
+# Pagination is 0-indexed (responses report "currentPage": 0 for the first page).
 
-# dataCite_df - the dataframe returned by function getNERCDataDOIs.py
+import requests
+import pandas as pd
+import time
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
-def getScholixCitations(dataCite_df):
-    import requests
-    import numpy as np
-    import pandas as pd
-    import time
-    
-    scholexInfo = [] # create an empty list in which all the Scholex info will be placed
-    
-    dataDOIs = list(dataCite_df['data_doi'])
-    # dataPublisher = list(dataCite_df['data_publisher'])
-    # dataTitle = list(dataCite_df['data_title'])
-    # dataAuthors = list(dataCite_df['data_authors'])
-    
-    scholix_url = 'http://api.scholexplorer.openaire.eu/v2/Links?'
+SCHOLIX_V3_BASE = "https://api.scholexplorer.openaire.eu/v3/Links"
 
-    # loop through info from the DataCite dataframe
-    # for doi, publisher, title, authors in zip(dataDOIs, dataPublisher, dataTitle, dataAuthors):
-    for doi in dataDOIs:
-        headers = {'sourcePid': doi}
-        r = requests.get(scholix_url, headers)
-        print(headers)
-        print('Status: ',  r.status_code)
-               
-        # scholex API holds no further info if no citations, therefore need a catcher to skip to the next record here
-        if r.json()['totalLinks'] == 0:
+# Column contract kept identical to the previous version so the downstream
+# processScholixCitations / merge steps are unaffected.
+COLUMN_NAMES = ["relation_type", "pub_title", "pub_date", "pub_authors",
+                "pub_type", "pub_publisher", "pub_doi", "data_doi"]
+
+
+def _first_doi(identifiers):
+    """Return the first DOI from a Scholix Identifier list, else None."""
+    for idinfo in identifiers or []:
+        if idinfo.get("IDScheme") == "doi" and idinfo.get("ID"):
+            return idinfo["ID"]
+    return None
+
+
+def getScholixCitations(dataCite_df, scholix_base=SCHOLIX_V3_BASE, relation=None,
+                        subtypes=None, page_size=100, max_pages=1000, delay=0.2,
+                        timeout=30):
+    """
+    For each dataset DOI in dataCite_df, fetch the works that cite/relate to it
+    from Scholexplorer v3 and return them merged back onto dataCite_df.
+
+    Parameters
+    ----------
+    relation : optional Scholix verb passed straight to the API (e.g. "Cites").
+        Default None = fetch all incoming relations (do not pre-filter at the API).
+    subtypes : optional iterable of RelationshipType SubType values to keep
+        (compared lower-cased, e.g. {"cites", "references", "issupplementto"}).
+        Default None = keep every incoming relation. The relation Name/SubType is
+        always recorded in `relation_type` so downstream can filter later.
+    """
+    keep_subtypes = {s.lower() for s in subtypes} if subtypes else None
+
+    session = requests.Session()
+    retries = Retry(total=5, backoff_factor=1,
+                    status_forcelist=[429, 500, 502, 503, 504], raise_on_status=False)
+    adapter = HTTPAdapter(max_retries=retries)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+
+    scholexInfo = []
+
+    for doi in list(dataCite_df["data_doi"]):
+        if not isinstance(doi, str) or not doi.strip():
             continue
-        else:
-            numPages = np.arange(0,r.json()['totalPages']) # create an array from 0 to the total number of pages of results to loop through
 
-            for page in numPages:
-                scholix_url_pages = scholix_url + 'page=' + str(page)
-                r = requests.get(scholix_url_pages, headers)
-                
-                # if 'result' in r.json():
+        page = 0
+        total_pages = 1  # updated from the first response
+        while page < total_pages and page < max_pages:
+            params = {"targetPid": doi, "page": page, "size": page_size}
+            if relation:
+                params["relation"] = relation
+            try:
+                r = session.get(scholix_base, params=params, timeout=timeout)
+                if r.status_code != 200:
+                    print(f"Status {r.status_code} for {doi} (page {page})")
+                    break
+                payload = r.json()
+            except requests.RequestException as e:
+                print(f"Request error for {doi} (page {page}): {e}")
+                break
+            except ValueError:
+                print(f"Non-JSON response for {doi} (page {page})")
+                break
+
+            total_links = payload.get("totalLinks", 0) or 0
+            total_pages = payload.get("totalPages", 0) or 0
+            results = payload.get("result") or []
+            # PID-scoped totals are reliable, but broad-query totals can come back
+            # negative/garbage, so an empty page is the definitive stop signal.
+            if total_links <= 0 or not results:
+                break  # no (further) citations recorded for this dataset
+
+            for link in results:
+                # Per-record handling: one malformed link must not drop the page.
                 try:
-                    pageRecords = range(len(r.json()['result']))
+                    rel = link.get("RelationshipType") or {}
+                    subtype = (rel.get("SubType") or "")
+                    if keep_subtypes is not None and subtype.lower() not in keep_subtypes:
+                        continue
 
-                    # loop through records again to collect info this time - this needs to be a seperate block in order to add the completed citation count 
-                    for citationNum in pageRecords:
-                        
-                        ### move this gbif skip to the filter section in merge results ###
-                        # if "10.15468" in r.json()['result'][citationNum]['target']['Identifier'][0]['ID']: # skip the gbif records
-                        #     print('Skip GBif')
-                        #     continue
-                        # else:
-                        for IDinfo in r.json()['result'][citationNum]['target']['Identifier']: # for each ID type for this publication e.g. DOI, pubmed etc
-                            pubDOI = None
+                    source = link.get("source") or {}        # the citing work
+                    publishers = source.get("Publisher") or []
+                    rel_str = "/".join(x for x in (rel.get("Name"), rel.get("SubType")) if x)
 
-                            if IDinfo['IDScheme'] == 'doi':
-                                pubDOI =  IDinfo['ID']
-                                break
-                            if IDinfo['IDScheme'] == 'handle':
-                                pubDOI =  IDinfo['ID']
-                                break
-                            elif IDinfo['IDScheme'] == 'pmid':
-                                pubDOI =  IDinfo['ID']
-                            elif IDinfo['IDScheme'] == 'pmc':
-                                pubDOI =  IDinfo['ID']
-                            else:
-                                print('Unknown or new ID type:', IDinfo)
-                                pubDOI = str(IDinfo) # it must be someother ID scheme
+                    scholexInfo.append([
+                        rel_str,
+                        source.get("Title"),
+                        source.get("PublicationDate"),
+                        source.get("Creator") or [],          # list of {name, ...}
+                        source.get("Type"),
+                        publishers[0].get("name") if publishers else None,
+                        _first_doi(source.get("Identifier")),
+                        doi,                                   # the dataset we queried
+                    ])
+                except Exception as e:
+                    print(f"Skipping malformed record for {doi}: {e}")
+                    continue
 
-#                             # there can be multiple ID schemes so we only want DOI of the publication:
-#                             for IDinfo in r.json()['result'][citationNum]['target']['Identifier']: # for each ID type for this publication e.g. DOI, pubmed etc
-#                                 if IDinfo['IDScheme'] == 'doi': # if its DOI, collect it and then skip to next part of code
-#                                     pubDOI =  IDinfo['ID']
-#                                     break
-#                                 elif IDinfo['IDScheme'] == 'pmid':
-#                                     pubDOI =  IDinfo['ID']
-#                                 elif IDinfo['IDScheme'] == 'pmc':
-#                                     pubDOI =  IDinfo['ID']
-                                
-#                                 else: # if there's no DOI then collect all the ID (to be looked at manually later)
-#                                     pubDOI =  r.json()['result'][citationNum]['target']['Identifier']
+            page += 1
+            if delay:
+                time.sleep(delay)
 
-                        #only get certain relation types
-                        if r.json()['result'][citationNum]['RelationshipType']['Name'] == "IsReferencedBy": # or r.json()['result'][citationNum]['RelationshipType']['Name'] == 'IsRelatedTo':   
-                            scholexInfo.append([
-                                            r.json()['result'][citationNum]['RelationshipType']['Name'],
-                                            r.json()['result'][citationNum]['target']['Title'],
-                                            r.json()['result'][citationNum]['target']['PublicationDate'],
-                                            r.json()['result'][citationNum]['target']['Creator'],
-                                            r.json()['result'][citationNum]['target']['Type'],
-                                            r.json()['result'][citationNum]['target']['Publisher'][0]['name'],
-                                            pubDOI, 
-                                            doi]) # info from dataCite_df
-                        else:
-                            continue
-
-                except:
-                    # Handle the case when 'result' key is absent
-                    print("No results found:", headers)
-   
-                    
-    # put the collected info into a dataframe                
-    column_names = ["relation_type", "pub_title", "pub_date", "pub_authors", "pub_type", "pub_publisher", "pub_doi", "data_doi"]
-    scholex_df = pd.DataFrame(scholexInfo, columns = column_names) 
-
-
-    # merge with dataCite_df
+    scholex_df = pd.DataFrame(scholexInfo, columns=COLUMN_NAMES)
 
     scholex_df_merged = scholex_df.merge(
         dataCite_df,
-        left_on='data_doi',
-        right_on='data_doi',
-        how='left'
+        on="data_doi",
+        how="left",
     )
 
-    print('Done!')
+    print("Done!")
     return scholex_df_merged


### PR DESCRIPTION
# Migrate Scholix citation retrieval to OpenAIRE Scholexplorer v3

## Summary

Rewrites `getScholixCitations` against the OpenAIRE Scholexplorer **v3** API and
corrects the relationship direction/filter, which under v2 was dropping Scholix
citations (a contributor to #11 on the Scholix side). Output columns are
unchanged, so `processScholixCitations`, `getPublicationType_forScholex`, and the
merge step are unaffected.

Separate from the encoding/year-filter MR; suggested branch
`fix/scholix-v3-migration`.

## Why the v2 path was losing citations

Verified against the official v3 docs (use-case + query-params pages) and the
example responses:

- **Relationships are stored on the active side of the verb** — "A Cites B",
  never "B IsCitedBy A". To get the works that cite a dataset, the dataset is the
  **target** and the citing work is the **source**. So citations are retrieved
  with `targetPid=<dataset DOI>`, reading `source`.
- **The semantic lives in `RelationshipType.SubType`** (e.g. `"cites"`).
  `RelationshipType.Name` is the generic `"IsRelatedTo"` in v3.
- **Pagination is 0-indexed** — responses report `"currentPage": 0` for the first
  page.

The v2 code did the opposite on both counts: it queried `sourcePid=<dataset DOI>`
(relations *from* the dataset, not citations *to* it) and kept only
`RelationshipType.Name == "IsReferencedBy"` — a value v3 never returns. Net
effect: wrong side queried *and* a filter that matches nothing, so the Scholix
source contributed little or nothing. It also discarded an entire page of results
whenever a single record was malformed (broad per-page `except`).

## Changes (`citations_fun/getScholixCitations.py`, v3 rewrite)

- Query `https://api.scholexplorer.openaire.eu/v3/Links?targetPid=<doi>` and read
  the citing work from `source`.
- Record `relation_type` as `Name/SubType` (e.g. `IsRelatedTo/cites`) so the real
  semantic is preserved and downstream can filter on it.
- **Per-record** error handling — one malformed link is skipped, not the whole
  page (fixes the v2 whole-page loss).
- 0-indexed paging with `size=100`; stop on an empty page as well as on
  `totalLinks <= 0` (broad-query totals can be negative/garbage, though
  PID-scoped totals are reliable); `max_pages` safety cap.
- Explicit `params=`, HTTPS, and a retry/backoff adapter.
- Extract the publication DOI from `source.Identifier` where `IDScheme == "doi"`.
- Pull authors from `source.Creator` (list of `{name, …}`) — same shape
  `processScholixCitations` already expects.
- Configurable filters: `relation=` (server-side, e.g. `"Cites"`) and `subtypes=`
  (client-side allowlist, e.g. `{"cites","references","issupplementto"}`).
  **Default: keep all incoming relations.**
- **Output column contract unchanged:** `[relation_type, pub_title, pub_date,
  pub_authors, pub_type, pub_publisher, pub_doi, data_doi]`, merged onto
  `dataCite_df` on `data_doi`.

## Testing

- Compiles; structural parse test against the documented v3 response payload.
  From the example link it correctly extracts the citing work's DOI
  (`10.1108/k-08-2023-1556`), title, publisher (`Kybernetes`), type
  (`literature`), date, authors, and `relation_type` (`IsRelatedTo/cites`), with
  `data_doi` set to the queried PID and the row merged back onto `dataCite_df`.
- `subtypes` allowlist verified (`{"references"}` → 0 rows, `{"cites"}` → 1 row).

## Behaviour change for reviewers

This is **more inclusive** than the old `IsReferencedBy`-only filter, so expect
**more** Scholix citations than before. `relation_type` values now look like
`IsRelatedTo/cites` rather than `IsReferencedBy`. Diff the Scholix intermediate
(`Results/intermediate_data/latest_results_scholex.*`) before/after.

## Reviewer decision needed — default relation/subtype policy

The rewrite defaults to keeping **all** incoming relations and recording the
SubType. Options:
- Keep all (current default) and let `filterCitations`/inspection decide.
- Restrict server-side with `relation="Cites"`.
- Restrict client-side with a `subtypes` allowlist (e.g.
  `{"cites","references","issupplementto"}`).

Inbound relations also include non-citation links (e.g. `isderivedfrom` for GBIF
downloads, `IsNewVersionOf`, `IsIdenticalTo`); GBIF is already dropped downstream,
but the team should confirm which SubTypes count as a citation.

## Integration

- Replaces `citations_fun/getScholixCitations.py` on merge. The notebook import
  (`from citations_fun.getScholixCitations import getScholixCitations`) is
  unchanged.
- v1/v2 of the API still exist; this moves us to v3 as recommended by OpenAIRE.